### PR TITLE
feat(seasons): pulse animation on active season indicator dot

### DIFF
--- a/app/assets/stylesheets/components/_seasons.scss
+++ b/app/assets/stylesheets/components/_seasons.scss
@@ -55,6 +55,28 @@
   &.is-active {
     background: var(--ed-accent);
     box-shadow: 0 0 0 3px rgba(255, 109, 56, 0.15);
+    animation: ed-season-hero-pulse 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes ed-season-hero-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 109, 56, 0.55);
+    transform: scale(1);
+  }
+  70% {
+    box-shadow: 0 0 0 8px rgba(255, 109, 56, 0);
+    transform: scale(1.15);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 109, 56, 0);
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ed-season-hero__dot.is-active {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
Agrega una animación de "latido" al punto indicador (.ed-season-hero__dot) cuando la temporada está vigente, reforzando visualmente que se trata de un estado activo y en curso.

**Cambios**

- Nuevo keyframe ed-season-hero-pulse (1.6s, ease-in-out, infinito) que combina expansión de box-shadow con un leve scale (1 → 1.15 → 1).

- La animación se aplica únicamente sobre .ed-season-hero__dot.is-active, por lo que las temporadas archivadas siguen **mostrando el punto estático.**

Se respeta prefers-reduced-motion: reduce deshabilitando la animación para usuarios con esa preferencia.

Alcance

1. Solo CSS. Sin cambios en Scala, plantillas Twirl ni en el modelo de datos.
2. Archivo modificado: _seasons.scss.