### PR TITLE
feat(sidebar): minimalist theme toggle, refined logout & rail-toggle,…

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -3,14 +3,37 @@
 // ============================================
 
 .ed-sidebar-footer {
-  padding: 1.5rem;
+  padding: 0.75rem 1.5rem;
   border-top: 1px solid var(--ed-border);
   font-family: $font-mono;
   font-size: 0.6rem;
   color: var(--ed-text-faint);
   letter-spacing: 0.1em;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-height: 0;
 
+  > span { color: var(--ed-accent); } // legacy
+}
+
+.ed-sidebar-footer__year {
+  flex: 1;
+  min-width: 0;
+  line-height: 1.2;
   span { color: var(--ed-accent); }
+}
+
+// El toggle queda inline en el footer, compacto y sin márgenes extra.
+.ed-sidebar-footer .ed-theme-toggle {
+  margin: 0;
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+
+  .ed-theme-toggle__glyph { font-size: 0.85rem; }
 }
 
 // Footer dentro de páginas content (legal, error, etc.)

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -33,6 +33,7 @@
   .ed-user-role,
   .ed-auth-cta,
   .ed-sidebar-footer,
+  .ed-sidebar-rule,
   .ed-theme-toggle { display: none !important; }
 
   // Truco: los items contienen text-nodes sueltos ("Portada", "Artículos"…),
@@ -135,8 +136,19 @@
   .ed-nav-section { padding: 0 0.5rem; }
   .ed-sidebar-auth { padding: 0.5rem; text-align: center; }
 
+  // Rail: apilar avatar + logout verticalmente, centrados
+  .ed-user-block {
+    flex-direction: column;
+    align-items: center;
+    gap: $space-2;
+  }
+  .ed-user-avatar { margin: 0 auto; }
+  .ed-user-logout { margin: 0 auto; }
+
   // Botón "expandir": invertimos el chevron cuando está colapsado.
-  .ed-sidebar__rail-toggle svg { transform: rotate(180deg); }
+  .ed-sidebar__rail-toggle .ed-sidebar__rail-toggle-chevron {
+    transform: rotate(180deg);
+  }
 }
 
 // ── Drawer mobile (controlado por sidebar.js + .is-open) ──
@@ -169,24 +181,40 @@
 .ed-no-scroll { overflow: hidden; }
 
 // ── Botón de toggle del rail (oculto en mobile) ──
-// Reubicado debajo del brand mediante `order` (sidebar es flex column).
+// Anclado al pie de la sidebar (debajo del footer) mediante `order` alto.
 .ed-sidebar__rail-toggle {
   display: none;
   align-items: center;
   justify-content: center;
-  order: 2; // brand=auto(1), toggle=2, nav=3, etc.
-  margin: 0 auto $space-4;
-  width: 32px;
-  height: 32px;
-  background: transparent;
+  order: 99; // siempre al final del flex column
+  margin: $space-3 auto $space-4;
+  width: 36px;
+  height: 36px;
+  background: var(--color-surface-sunken);
   border: 1px solid var(--color-border-subtle);
   border-radius: $radius-md;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-secondary);
   cursor: pointer;
+  transition:
+    background $duration-fast $ease-out,
+    color $duration-fast $ease-out,
+    border-color $duration-fast $ease-out,
+    transform $duration-fast $ease-out;
 
   @include focus-ring(2px);
-  &:hover { color: var(--color-text-primary); background: var(--color-surface-sunken); }
-  svg { width: 14px; height: 14px; }
+  &:hover {
+    color: var(--color-text-primary);
+    background: var(--color-surface-raised);
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
+  }
+  &:active { transform: translateY(0); }
+
+  .ed-sidebar__rail-toggle-icon { width: 18px; height: 18px; }
+  .ed-sidebar__rail-toggle-chevron {
+    transition: transform $duration-fast $ease-out;
+    transform-origin: 15.5px 12px;
+  }
 
   @media (min-width: $bp-md) { display: inline-flex; }
 }
@@ -428,21 +456,65 @@
 }
 
 .ed-user-logout {
-  background: none;
-  border: none;
-  color: var(--ed-text-faint);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 50%;
+  color: var(--color-text-tertiary);
   cursor: pointer;
-  font-size: 0.9rem;
-  padding: 0.2rem;
-  transition: color 0.15s;
   flex-shrink: 0;
   text-decoration: none;
+  transition:
+    color $duration-fast $ease-out,
+    background $duration-fast $ease-out,
+    border-color $duration-fast $ease-out;
 
-  &:hover { color: var(--ed-text); }
+  svg { width: 16px; height: 16px; display: block; }
+
+  &:hover {
+    color: var(--color-accent);
+    background: var(--color-surface-sunken);
+    border-color: var(--color-accent);
+  }
+
+  @include focus-ring(2px);
 }
 
 .ed-auth-cta {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+}
+
+// ── Divisor ornamental del sidebar (línea ··· ❦ ··· línea) ──
+.ed-sidebar-rule {
+  display: flex;
+  align-items: center;
+  gap: $space-2;
+  margin: $space-3 1.25rem;
+  opacity: 0.85;
+}
+
+.ed-sidebar-rule__line {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    var(--color-border-subtle) 25%,
+    var(--color-border-subtle) 75%,
+    transparent
+  );
+}
+
+.ed-sidebar-rule__mark {
+  font-family: $font-display;
+  font-size: 0.95rem;
+  line-height: 1;
+  color: var(--ed-accent);
+  user-select: none;
 }

--- a/app/assets/stylesheets/components/_theme-toggle.scss
+++ b/app/assets/stylesheets/components/_theme-toggle.scss
@@ -1,115 +1,77 @@
 // ============================================
-// Theme Toggle — switcher tri-estado (claro · oscuro · auto)
-// Issue #16-D · ARIA radiogroup
+// Theme Toggle — botón único (claro ↔ oscuro)
+// Muestra el glifo del tema OPUESTO al activo.
 // ============================================
 
 .ed-theme-toggle {
   display: inline-flex;
   align-items: center;
-  gap: $space-1;
-  padding: $space-1;
-  background: var(--color-surface-sunken);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: $radius-pill;
-  width: fit-content;
-}
-
-.ed-theme-toggle__btn {
-  display: inline-flex;
-  align-items: center;
-  gap: $space-1;
-  padding: $space-1 $space-3;
-  min-height: 32px;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   background: transparent;
   border: none;
-  border-radius: $radius-pill;
+  border-radius: 50%;
   color: var(--color-text-tertiary);
-  font-family: $font-mono;
-  font-size: 0.62rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
   cursor: pointer;
+  position: relative;
   transition:
-    background $duration-fast $ease-out,
-    color $duration-fast $ease-out;
+    color $duration-fast $ease-out,
+    transform $duration-fast $ease-out;
 
-  &:hover { color: var(--color-text-primary); }
-
-  &[aria-checked="true"],
-  &.is-active {
-    background: var(--color-accent);
-    color: var(--color-on-accent);
+  &:hover {
+    color: var(--color-text-primary);
+    transform: scale(1.08);
   }
 
   @include focus-ring(2px);
 }
 
-.ed-theme-toggle__icon {
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-  stroke: currentColor;
-  fill: none;
+.ed-theme-toggle__glyph {
+  font-size: 1.05rem;
+  line-height: 1;
+  display: none;
 }
 
-.ed-theme-toggle__label {
-  font: inherit;
-  color: inherit;
+// Modo oscuro activo → mostrar SOL (ofrece pasar a claro)
+:root[data-theme="noche"] .ed-theme-toggle__glyph--sun { display: inline-flex; }
+// Modo claro activo → mostrar LUNA (ofrece pasar a oscuro)
+:root[data-theme="crema"] .ed-theme-toggle__glyph--moon { display: inline-flex; }
+// Auto / sin definir → seguimos preferencia del sistema
+:root:not([data-theme="crema"]):not([data-theme="noche"]) {
+  .ed-theme-toggle__glyph--moon { display: inline-flex; }
+  @media (prefers-color-scheme: dark) {
+    .ed-theme-toggle__glyph--moon { display: none; }
+    .ed-theme-toggle__glyph--sun  { display: inline-flex; }
+  }
 }
 
-// ── Variante compacta (sólo iconos) ──
+.ed-theme-toggle__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// ── Variante compacta ──
 .ed-theme-toggle--compact {
-  .ed-theme-toggle__btn {
-    padding: 0;
-    width: 30px;
-    height: 30px;
-    justify-content: center;
-  }
-  .ed-theme-toggle__label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    white-space: nowrap;
-    border: 0;
-  }
+  width: 30px;
+  height: 30px;
 }
 
-// ── Integración en sidebar editorial ──
-// Variante icon-only forzada: el sidebar es estrecho y los labels desbordan.
+// ── Sidebar editorial ──
 .ed-sidebar .ed-theme-toggle {
   margin: $space-3 $space-4;
-  max-width: calc(100% - #{$space-4} * 2);
-  box-sizing: border-box;
-
-  .ed-theme-toggle__btn {
-    padding: 0 !important;
-    width: 32px !important;
-    min-width: 32px !important;
-    height: 32px !important;
-    flex: 0 0 32px !important;
-    justify-content: center;
-    gap: 0 !important;
-  }
-  // Ocultamos el texto: el icono y el aria-label cubren la accesibilidad.
-  .ed-theme-toggle__label {
-    display: none !important;
-  }
 }
 
-// ── Integración en topbar admin (fondo oscuro) ──
+// ── Topbar admin (fondo oscuro) ──
 .ed-bo .ed-theme-toggle {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.12);
-
-  .ed-theme-toggle__btn {
-    color: rgba(255, 255, 255, 0.6);
-    &:hover { color: #fff; }
-    &[aria-checked="true"],
-    &.is-active {
-      background: var(--color-accent);
-      color: var(--color-on-accent);
-    }
-  }
+  color: rgba(255, 255, 255, 0.7);
+  &:hover { color: #fff; }
 }

--- a/app/views/partials/sidebar.scala.html
+++ b/app/views/partials/sidebar.scala.html
@@ -99,9 +99,12 @@
   <button type="button"
           class="ed-sidebar__rail-toggle"
           data-action="toggle-rail"
-          aria-label="Colapsar/expandir navegación">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <polyline points="15 18 9 12 15 6"></polyline>
+          aria-label="Colapsar/expandir navegación"
+          title="Colapsar/expandir navegación">
+    <svg class="ed-sidebar__rail-toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+      <line x1="9" y1="4" x2="9" y2="20"></line>
+      <polyline class="ed-sidebar__rail-toggle-chevron" points="14 9 17 12 14 15"></polyline>
     </svg>
   </button>
 
@@ -218,8 +221,12 @@
     }
   </nav>
 
-  @* Issue #16-D: switcher de tema (radiogroup ARIA). *@
-  @partials.themeToggle()
+  @* Divisor ornamental — separa controles superiores del bloque de cuenta. *@
+  <div class="ed-sidebar-rule" aria-hidden="true">
+    <span class="ed-sidebar-rule__line"></span>
+    <span class="ed-sidebar-rule__mark">❦</span>
+    <span class="ed-sidebar-rule__line"></span>
+  </div>
 
   <div class="ed-sidebar-auth">
     @if(userId.isDefined) {
@@ -229,7 +236,13 @@
           <div class="ed-user-name">@userName</div>
           <div class="ed-user-role">@roleLabel</div>
         </div>
-        <a href="@routes.AuthController.logout()" class="ed-user-logout" title="Cerrar sesión" aria-label="Cerrar sesión">↪</a>
+        <a href="@routes.AuthController.logout()" class="ed-user-logout" title="Cerrar sesión" aria-label="Cerrar sesión">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
+            <polyline points="16 17 21 12 16 7"></polyline>
+            <line x1="21" y1="12" x2="9" y2="12"></line>
+          </svg>
+        </a>
       </div>
     } else {
       <div class="ed-auth-cta">
@@ -240,6 +253,8 @@
   </div>
 
   <div class="ed-sidebar-footer">
-    Año Cero · <span>2025</span>
+    <span class="ed-sidebar-footer__year">Año Cero · <span>2025</span></span>
+    @* Toggle de tema — alineado con el footer del sidebar. *@
+    @partials.themeToggle()
   </div>
 </aside>

--- a/app/views/partials/themeToggle.scala.html
+++ b/app/views/partials/themeToggle.scala.html
@@ -1,49 +1,17 @@
 @(compact: Boolean = false)
 
 @*
-  Switcher de tema accesible (3 modos: claro / oscuro / auto).
-  Patrón ARIA: radiogroup con tres `role="radio"`.
-  Issue #16-D · WCAG 2.1 AA.
+  Toggle de tema simple (binario: claro / oscuro).
+  Un único botón que muestra el glifo del tema opuesto al activo.
+  Glifos: ☀ (cambiar a claro) · ☾ (cambiar a oscuro).
 *@
 
-<div class="ed-theme-toggle @if(compact){ed-theme-toggle--compact}"
-     role="radiogroup"
-     aria-label="Apariencia">
-  <button type="button"
-          class="ed-theme-toggle__btn"
-          role="radio"
-          aria-checked="false"
-          data-theme-value="crema"
-          aria-label="Tema claro">
-    <svg class="ed-theme-toggle__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <circle cx="12" cy="12" r="4"></circle>
-      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
-    </svg>
-    <span class="ed-theme-toggle__label">Claro</span>
-  </button>
-
-  <button type="button"
-          class="ed-theme-toggle__btn"
-          role="radio"
-          aria-checked="false"
-          data-theme-value="noche"
-          aria-label="Tema oscuro">
-    <svg class="ed-theme-toggle__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-    </svg>
-    <span class="ed-theme-toggle__label">Oscuro</span>
-  </button>
-
-  <button type="button"
-          class="ed-theme-toggle__btn"
-          role="radio"
-          aria-checked="true"
-          data-theme-value="auto"
-          aria-label="Tema automático según el sistema">
-    <svg class="ed-theme-toggle__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <rect x="2" y="4" width="20" height="14" rx="2"></rect>
-      <path d="M8 22h8M12 18v4"></path>
-    </svg>
-    <span class="ed-theme-toggle__label">Auto</span>
-  </button>
-</div>
+<button type="button"
+        class="ed-theme-toggle @if(compact){ed-theme-toggle--compact}"
+        data-theme-toggle
+        aria-label="Cambiar tema"
+        title="Cambiar tema">
+  <span class="ed-theme-toggle__glyph ed-theme-toggle__glyph--sun" aria-hidden="true">☀</span>
+  <span class="ed-theme-toggle__glyph ed-theme-toggle__glyph--moon" aria-hidden="true">☾</span>
+  <span class="ed-theme-toggle__sr">Cambiar tema</span>
+</button>

--- a/public/javascripts/theme.js
+++ b/public/javascripts/theme.js
@@ -37,6 +37,7 @@
   }
 
   function syncToggles(theme) {
+    // Switcher legacy (radiogroup tri-estado)
     var btns = document.querySelectorAll('.ed-theme-toggle__btn[data-theme-value]');
     for (var i = 0; i < btns.length; i++) {
       var v = btns[i].getAttribute('data-theme-value');
@@ -45,10 +46,36 @@
       btns[i].classList.toggle('is-active', active);
       btns[i].tabIndex = active ? 0 : -1;
     }
+    // Botón único (toggle binario)
+    var single = document.querySelectorAll('[data-theme-toggle]');
+    for (var j = 0; j < single.length; j++) {
+      single[j].setAttribute('data-current-theme', theme);
+    }
+  }
+
+  function resolveBinary(theme) {
+    if (theme === 'crema' || theme === 'noche') return theme;
+    // 'auto' u otro → usar preferencia del sistema
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'noche';
+    }
+    return 'crema';
   }
 
   function bind() {
     document.addEventListener('click', function (ev) {
+      // Botón único → alterna claro/oscuro
+      var single = ev.target.closest && ev.target.closest('[data-theme-toggle]');
+      if (single) {
+        ev.preventDefault();
+        var current = resolveBinary(read());
+        var next = current === 'crema' ? 'noche' : 'crema';
+        write(next);
+        apply(next);
+        return;
+      }
+
+      // Switcher legacy con data-theme-value
       var btn = ev.target.closest && ev.target.closest('.ed-theme-toggle__btn[data-theme-value]');
       if (!btn) return;
       ev.preventDefault();


### PR DESCRIPTION
… footer rework

- themeToggle: simplified to single ☀/☾ button (binary), shows opposite glyph
- theme.js: handles new [data-theme-toggle] binary switcher (legacy radiogroup preserved)
- sidebar: logout now uses SVG icon in circular button; rail-toggle redesigned with panel-like icon
- sidebar footer: flex row hosting year + theme toggle, reduced padding (~3/4 height)
- new ed-sidebar-rule ornamental divider (line · ❦ · line)
- rail-mode: stack avatar + logout vertically, hide rule/footer/labels