### PR TITLE
fix(render): bind to IPv4 0.0.0.0 and build JDBC URL from DB_* env vars

### DIFF
--- a/conf/application.prod.conf
+++ b/conf/application.prod.conf
@@ -13,11 +13,20 @@ play.filters.hosts {
 }
 
 # Database Configuration for Production (PostgreSQL on Render)
+#
+# Render expone el connection string como `postgres://user:pass@host:port/db`
+# que NO es un JDBC URL válido. Para evitar el cuelgue al inicializar Slick
+# (que dejaba al servidor HTTP sin bindear y disparaba el "no open ports
+# detected" en Render), construimos el JDBC URL desde las variables
+# individuales DB_HOST / DB_PORT / DB_NAME / DB_USER / DB_PASSWORD que se
+# definen en render.yaml vía `fromDatabase`.
 slick.dbs.default {
   profile = "slick.jdbc.PostgresProfile$"
   db {
     driver = "org.postgresql.Driver"
-    url = ${?DATABASE_URL}
+    url  = "jdbc:postgresql://"${?DB_HOST}":"${?DB_PORT}"/"${?DB_NAME}"?sslmode=require"
+    user = ${?DB_USER}
+    password = ${?DB_PASSWORD}
     numThreads = 10
     maxConnections = 10
     minConnections = 2

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,12 @@ services:
     name: reactive-manifesto
     env: java
     buildCommand: sbt clean compile stage
-    startCommand: ./target/universal/stage/bin/web -Dhttp.port=$PORT -Dplay.http.secret.key=$APPLICATION_SECRET -Dconfig.file=conf/application.prod.conf
+    # IMPORTANTE:
+    # - http.address=0.0.0.0 → Render exige binding a 0.0.0.0 para detectar el puerto.
+    # - config.resource (NO config.file) carga el HOCON desde el classpath del jar
+    #   stageado. Con -Dconfig.file=conf/... el path es relativo y no existe en el
+    #   binario empaquetado, por lo que la app caía a application.conf por defecto.
+    startCommand: ./target/universal/stage/bin/web -Dhttp.port=$PORT -Dhttp.address=0.0.0.0 -Dplay.http.secret.key=$APPLICATION_SECRET -Dconfig.resource=application.prod.conf
     envVars:
       - key: APPLICATION_SECRET
         generateValue: true
@@ -12,12 +17,31 @@ services:
         value: -Xmx512m -Xms256m
       - key: SBT_OPTS
         value: -Xmx1024m -Xms512m
-      - key: DATABASE_URL
+      # Render expone el connection string como postgres://... que Slick/JDBC NO
+      # entienden (necesitan jdbc:postgresql://...). Usamos los campos individuales
+      # y construimos el JDBC URL en application.prod.conf.
+      - key: DB_HOST
         fromDatabase:
           name: reactive-manifesto-db
-          property: connectionString
+          property: host
+      - key: DB_PORT
+        fromDatabase:
+          name: reactive-manifesto-db
+          property: port
+      - key: DB_NAME
+        fromDatabase:
+          name: reactive-manifesto-db
+          property: database
+      - key: DB_USER
+        fromDatabase:
+          name: reactive-manifesto-db
+          property: user
+      - key: DB_PASSWORD
+        fromDatabase:
+          name: reactive-manifesto-db
+          property: password
     autoDeploy: true
-    healthCheckPath: /
+    healthCheckPath: /health
 
 databases:
   # PostgreSQL Database


### PR DESCRIPTION
- render.yaml: add -Dhttp.address=0.0.0.0 so Render's IPv4 port-scan detects the bound port (Play was binding to [::]:PORT).
- render.yaml: switch from DATABASE_URL (postgres://...) to individual DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD via fromDatabase, since Slick/JDBC require a jdbc:postgresql://... URL.
- render.yaml: use -Dconfig.resource (not -Dconfig.file) and point healthCheckPath to /health.
- application.prod.conf: build JDBC URL from DB_* vars with sslmode=require.