### PR TITLE
feat(publications): adaptive scroll UX — toolbar collapse, card revea…

### DIFF
--- a/app/assets/stylesheets/publications/_list.scss
+++ b/app/assets/stylesheets/publications/_list.scss
@@ -19,11 +19,11 @@
 }
 
 .ed-pub-header {
-  padding: 2.5rem 3.5rem 1.25rem;
+  padding: 1rem 3.5rem 0.5rem;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  gap: 2rem;
+  gap: 1.25rem;
   flex-wrap: wrap;
 }
 
@@ -33,7 +33,7 @@
   color: var(--color-text-tertiary);
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  margin-bottom: 0.6rem;
+  margin-bottom: 0.3rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -50,10 +50,10 @@
 
 .ed-pub-title {
   font-family: $font-display;
-  font-size: clamp(2rem, 3.5vw, 3.2rem);
+  font-size: clamp(1.35rem, 2vw, 1.9rem);
   font-weight: 900;
-  line-height: 1.02;
-  letter-spacing: -0.03em;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
   color: var(--color-text-primary);
 
   em {
@@ -68,7 +68,7 @@
   flex-wrap: nowrap;
   gap: 0.4rem;
   margin: 0;
-  padding: 0.75rem 3.5rem 1rem;
+  padding: 0.4rem 3.5rem 0.55rem;
   background: transparent;
   border: none;
   overflow-x: auto;
@@ -80,16 +80,18 @@
 
 // .ed-cat-pill — see tags/_category-pill.scss
 
+// ── Grid principal ──────────────────────────────────────────
 .ed-articles-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-  gap: 0;
-  padding: 2rem 2rem;
+  gap: 1.25rem;
+  padding: 0.75rem 3.5rem 2.5rem;
+  align-items: start;
 
   @media (max-width: 640px) {
     grid-template-columns: 1fr;
-    padding: 1rem;
-    gap: 1rem;
+    padding: 0.75rem 1rem 2rem;
+    gap: 0.85rem;
   }
 }
 
@@ -97,7 +99,7 @@
   padding: 2rem 2rem 1.75rem;
   border: 1px solid var(--color-border-subtle);
   border-radius: 12px;
-  margin: 0.6rem;
+  margin: 0;
   cursor: pointer;
   text-decoration: none;
   color: inherit;
@@ -145,6 +147,7 @@
     border-radius: 16px;
     border: none;
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+    min-height: 0;
 
     &::before { display: none; }
 
@@ -406,6 +409,128 @@ a.ed-article-tag {
     background: var(--color-accent-soft);
     box-shadow: 0 2px 10px rgba(var(--color-accent-rgb), 0.2);
     outline: none;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════
+// Adaptive scroll — UX adaptativo al hacer scroll
+// ═══════════════════════════════════════════════════════════
+
+// ── Contenedor de title + count: transiciona al colapsar ──────
+.ed-pub-header-info {
+  overflow: hidden;
+  max-height: 160px;
+  opacity: 1;
+  visibility: visible;
+  transition:
+    max-height 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity    0.22s ease,
+    visibility 0s   linear 0s;
+}
+
+// ── Toolbar colapsado cuando el user scrollea ─────────────────
+.ed-pub-toolbar.is-shrunk {
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.10), 0 1px 0 var(--color-border-subtle);
+
+  .ed-pub-header {
+    padding-block: 0.45rem;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  // Colapsamos título + count
+  .ed-pub-header-info {
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    transition:
+      max-height 0.3s  cubic-bezier(0.4, 0, 0.2, 1),
+      opacity    0.18s ease,
+      visibility 0s    linear 0.18s;
+  }
+
+  // El buscador gana todo el espacio disponible
+  .ed-search-wrap {
+    flex: 1 1 auto;
+  }
+
+  // Archive link → solo el ícono (sin texto)
+  .ed-pub-archive-link {
+    font-size: 0;
+    padding: 0.4rem 0.65rem;
+    gap: 0;
+
+    &__icon {
+      font-size: 0.95rem;
+    }
+  }
+
+  // Pills row más compacto
+  .ed-cat-row {
+    padding-block: 0.35rem 0.6rem;
+  }
+}
+
+// ── Cards bajo el fold: animación al entrar en viewport ───────
+@keyframes ed-scroll-reveal {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@include motion-safe {
+  // Clase asignada por JS para cancelar el stagger CSS en cards fuera de pantalla
+  .ed-articles-grid > .ed-article-card.below-fold {
+    animation: none !important;
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  // Clase asignada por IntersectionObserver cuando el card entra en viewport
+  .ed-articles-grid > .ed-article-card.is-scroll-revealed {
+    animation: ed-scroll-reveal 0.45s $ease-out both;
+    animation-delay: calc(var(--reveal-delay, 0) * 65ms);
+  }
+}
+
+// ── Botón flotante "volver arriba" ────────────────────────────
+.ed-backtop {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 60;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  line-height: 1;
+  box-shadow: 0 4px 16px rgba(var(--color-accent-rgb), 0.35);
+  opacity: 0;
+  transform: translateY(10px) scale(0.88);
+  transition: opacity 0.25s ease, transform 0.25s ease, background 0.18s ease, box-shadow 0.18s ease;
+  pointer-events: none;
+
+  &.is-visible {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+  }
+
+  &:hover {
+    background: var(--color-accent-hover);
+    box-shadow: 0 8px 24px rgba(var(--color-accent-rgb), 0.45);
+    transform: translateY(-2px) scale(1.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 3px;
   }
 }
 

--- a/app/views/sections/pubToolbar.scala.html
+++ b/app/views/sections/pubToolbar.scala.html
@@ -10,7 +10,7 @@
 
 <div class="ed-pub-toolbar">
   <header class="ed-pub-header">
-    <div>
+    <div class="ed-pub-header-info">
       <div class="ed-pub-count">@totalCount publicaciones · @seasonName.map(name => "Temporada: " + name).getOrElse("Flujo editorial continuo")</div>
       <h1 class="ed-pub-title">Artículos <em>@seasonName.map(_ => "de la temporada").getOrElse("publicados")</em></h1>
     </div>

--- a/public/javascripts/animations.js
+++ b/public/javascripts/animations.js
@@ -1,9 +1,13 @@
 /* ================================================================
  * animations.js — Stagger de cards + theme transition (Issue #18-C)
+ *                 + Adaptive scroll UX para /publicaciones
  *
  * - Asigna --i incremental a .ed-article-card (animation-delay).
  * - Al cambiar data-theme, aplica clase .ed-theming durante 400 ms
  *   para crossfade suave de background-color/color/border.
+ * - Toolbar colapsa al hacer scroll (is-shrunk).
+ * - Cards bajo el fold se revelan con IntersectionObserver.
+ * - Botón flotante "volver arriba" inyectado dinámicamente.
  * - Sin nada si prefers-reduced-motion: reduce.
  * ================================================================ */
 (function () {
@@ -37,6 +41,97 @@
     observer.observe(html, { attributes: true, attributeFilter: ['data-theme'] });
   }
 
-  if (document.readyState !== 'loading') { staggerCards(); watchTheme(); }
-  else document.addEventListener('DOMContentLoaded', function () { staggerCards(); watchTheme(); });
+  // 3. Adaptive scroll: toolbar collapse + card scroll-reveal + back-to-top.
+  function initPublicationsScroll() {
+    var toolbar = document.querySelector('.ed-pub-toolbar');
+    var grid    = document.querySelector('.ed-articles-grid');
+
+    if (!toolbar && !grid) return;
+
+    // ── 3a. Back-to-top button ──────────────────────────────────
+    var btn = document.createElement('button');
+    btn.className = 'ed-backtop';
+    btn.setAttribute('aria-label', 'Volver arriba');
+    btn.setAttribute('type', 'button');
+    btn.innerHTML = '&#8593;'; // ↑
+    document.body.appendChild(btn);
+
+    btn.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+
+    // ── 3b. Card scroll-reveal via IntersectionObserver ─────────
+    if (grid) {
+      var vh    = window.innerHeight;
+      var cards = Array.from(grid.querySelectorAll('.ed-article-card'));
+
+      // Mark below-fold cards: cancel CSS stagger animation and hide them.
+      var belowFold = cards.filter(function (c) {
+        return c.getBoundingClientRect().top > vh + 40;
+      });
+
+      belowFold.forEach(function (c) { c.classList.add('below-fold'); });
+
+      if (belowFold.length > 0 && 'IntersectionObserver' in window) {
+        var batchCounter = 0;
+
+        var revealObserver = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (!entry.isIntersecting) return;
+            var card  = entry.target;
+            var delay = batchCounter % 4; // stagger up to 4 per row
+            batchCounter++;
+            card.style.setProperty('--reveal-delay', delay);
+            card.classList.remove('below-fold');
+            card.classList.add('is-scroll-revealed');
+            revealObserver.unobserve(card);
+          });
+        }, { threshold: 0.06, rootMargin: '0px 0px -24px 0px' });
+
+        belowFold.forEach(function (c) { revealObserver.observe(c); });
+      } else {
+        // Fallback: show all immediately.
+        belowFold.forEach(function (c) { c.classList.remove('below-fold'); });
+      }
+    }
+
+    // ── 3c. Scroll handler: toolbar + back-to-top ───────────────
+    var SHRINK_AT  = 30;   // px — toolbar colapsa
+    var BACKTOP_AT = 400;  // px — botón aparece
+    var ticking    = false;
+
+    function onScroll() {
+      var y = window.scrollY;
+
+      if (toolbar) {
+        toolbar.classList.toggle('is-shrunk', y > SHRINK_AT);
+      }
+
+      btn.classList.toggle('is-visible', y > BACKTOP_AT);
+
+      ticking = false;
+    }
+
+    window.addEventListener('scroll', function () {
+      if (!ticking) {
+        requestAnimationFrame(onScroll);
+        ticking = true;
+      }
+    }, { passive: true });
+
+    // Trigger once on load in case page is restored mid-scroll.
+    onScroll();
+  }
+
+  if (document.readyState !== 'loading') {
+    staggerCards();
+    watchTheme();
+    initPublicationsScroll();
+  } else {
+    document.addEventListener('DOMContentLoaded', function () {
+      staggerCards();
+      watchTheme();
+      initPublicationsScroll();
+    });
+  }
 })();


### PR DESCRIPTION
…l, back-to-top

- Toolbar compacts on scroll (is-shrunk): title/count collapse, search expands, archive link shrinks to icon-only, pills row tightens
- Cards below the fold reveal with IntersectionObserver + staggered delay
- Floating back-to-top button (#ed-backtop) appears after 400px scroll
- Tighter initial header padding and smaller title font to maximise article space
- Grid padding aligned to toolbar (3.5rem) for consistent left edge
- Grid gap set to 1.25rem, card margin removed (gap-only spacing)
- Respects prefers-reduced-motion throughout